### PR TITLE
Represent arrays as Array.toString()

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -72,8 +72,8 @@
 
       if (util.isArray(item)) {
         // Arrays are a special case and should be handled within Tableau.
-        // We transform them back into JSON.
-        item = JSON.stringify(item);
+        // We just run the toString method on them.
+        item = item.toString();
       }
       else if (typeof item === 'object') {
         parent = ancestor + key + '.';


### PR DESCRIPTION
Instead of JSON.  ...For easier parsing and analysis in Tableau.